### PR TITLE
Removed fs-symlink dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -233,7 +233,6 @@ ScreenshotReporter.prototype.getJasmine2Reporter = function() {
 							util.storeMetaData(metaData, metaDataPath);
 						}
 					});
-					require('fs-symlink')(directory, path.resolve(directory, '..', '_latest'));
 				});
 			});
 		}
@@ -298,7 +297,6 @@ function reportSpecResults(spec) {
 					util.storeMetaData(metaData, metaDataPath);
 				}
 			});
-			require('fs-symlink')(directory, path.resolve(directory, '..', '_latest'));
 		});
 	});
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "protractor-angular-screenshot-reporter",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "An npm module and which generates your Protractor test reports in HTML (angular) with screenshots",
   "main": "index.js",
   "repository": {
@@ -9,8 +9,7 @@
   },
   "dependencies": {
     "mkdirp": "~0.3.5",
-    "underscore": "~1.6.0",
-    "fs-symlink": "~1.2.1"
+    "underscore": "~1.6.0"
   },
   "keywords": [
     "screenshot",


### PR DESCRIPTION
- The link to be created is never used (i don't see where)
- The fs-symlink requires admin access if not => UnhandledPromiseRejectionWarning because of Node 6+

If required by someone, we can create flag to use it or not 